### PR TITLE
Controlling "debug mode" fixed.

### DIFF
--- a/view/frontend/web/js/infinitescroll.js
+++ b/view/frontend/web/js/infinitescroll.js
@@ -18,7 +18,7 @@ define([
 ], function($, jqueryIas, infinitescroll) {
     "use strict";
     window.SgyIAS = {
-        debug: window.iasConfig.mode,
+        debug: window.iasConfig.debug,
         _log: function(object) {
             if(this.debug) {
                 console.log(object);


### PR DESCRIPTION
Configuration *( allowing or disabling )* "debug mode" in Magento configuration is ignored, because of wrong property in `infinitescroll.js` file.

This pull request fixing it. 