### PR TITLE
Fix for Ajax add to Cart on Ajax loaded products

### DIFF
--- a/view/frontend/web/js/infinitescroll.js
+++ b/view/frontend/web/js/infinitescroll.js
@@ -87,6 +87,7 @@ define([
                 });
                 window.ias.on('rendered', function(items){
                     SgyIAS._log({eventName: 'render', items: items});
+                    $("form[data-role='tocart-form']").catalogAddToCart();
                 });
                 window.ias.on('noneLeft', function(){
                     SgyIAS._log({eventName: 'noneLeft'});


### PR DESCRIPTION
x magento init scripts are not initialised when loaded over ajax. This fixes the ajax add to cart buttons once the new products are rendered