### PR TITLE
Update js.phtml

### DIFF
--- a/view/frontend/templates/js.phtml
+++ b/view/frontend/templates/js.phtml
@@ -49,8 +49,8 @@
             toolbarAction: '<?php echo $block->getDesign('hide_toolbar') ? 'hide' : 'show'; ?>',
             memoryActive: <?php echo $block->isMemoryActive() ? 'true' : 'false'; ?>
         };
-        require(['jquery', 'jqueryIas', 'infinitescroll'], function($){
-            $(window).load(function() {
+        require(['jquery', 'infinitescroll'], function($){
+            $(function($) {
                 // InfiniteScroll:
                 SgyIAS.init();
             });


### PR DESCRIPTION
When including jqueryIas in js.phtml it will return jquery not define. So it's better to leave jqueryIas loaded through infinitescroll.js jquery dependency.