### PR TITLE
Fix using product item

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -32,8 +32,8 @@
                 <content>.column.main</content>
                 <next>.next</next>
                 <previous>.previous</previous>
-                <items_grid>.products-grid</items_grid>
-                <items_list>.products-list</items_list>
+                <items_grid>.product-item</items_grid>
+                <items_list>.product-item</items_list>
                 <loading>.column.main</loading>
                 <toolbar>.toolbar</toolbar>
                 <pagination>.toolbar .limiter</pagination>


### PR DESCRIPTION
After installing module to magento2 project I see that when 2nd page was loaded - new div with "div.products-grid" was created, below existing one, while it's container for products, it's not actual products.
![capture 2018-06-01 at 14 57 33](https://user-images.githubusercontent.com/1873745/41230352-23c16fe4-6d88-11e8-9b3b-d220a0740bf1.png)

My fix replacing item selector to use actual products. After my change it looks like this:
![capture 2018-06-01 at 14 55 34](https://user-images.githubusercontent.com/1873745/41230376-3a83f422-6d88-11e8-9baa-82bb22f87c04.png)

Also for product grid and product list these selectors are even equal, but for reasons of using on custom themes let's keep it as it was previously.