### PR TITLE
Fix selector for pagination

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -36,7 +36,7 @@
                 <items_list>.products-list</items_list>
                 <loading>.column.main</loading>
                 <toolbar>.toolbar</toolbar>
-                <pagination>.toolbar .limiter</pagination>
+                <pagination>.toolbar .pages</pagination>
             </selectors>
             <design>
                 <loading_img><![CDATA[]]></loading_img>


### PR DESCRIPTION
Before this change module was hiding limitation block, while pagination was shown (and links in it led to page reload):
![image](https://user-images.githubusercontent.com/1873745/41230788-c02dfc70-6d89-11e8-8e87-90ce95299888.png)


Now it looks like this (end of the page):
![image](https://user-images.githubusercontent.com/1873745/41230712-830a2fa8-6d89-11e8-86dc-32f6c269671d.png)


Theme using default magento + customized css (not changing page structure)