### PR TITLE
Disable debug by default

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -19,8 +19,7 @@
         <strategery_infinitescroll>
             <general>
                 <enabled>1</enabled>
-                <debug>1</debug>
-                <jquery>1</jquery>
+                <debug>0</debug>
             </general>
             <instances>
                 <grid>1</grid>


### PR DESCRIPTION
It's better to make module configured with disabled "debug" mode, for using on production it's better. Developers still could enable this feature if needed in the admin.

Also this PR removed not needed "jquery" configuration node, that wasn't used anywhere