### PR TITLE
Hide toolbar by default

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -41,7 +41,7 @@
                 <loading_img><![CDATA[]]></loading_img>
                 <loading_text><![CDATA[<em>Loading products...</em>]]></loading_text>
                 <done_text><![CDATA[<em>Congratulations, you've reached the end of the internet.</em>]]></done_text>
-                <hide_toolbar>0</hide_toolbar>
+                <hide_toolbar>1</hide_toolbar>
                 <local_mode>0</local_mode>
                 <extra_scroll_px>150</extra_scroll_px>
                 <buffer_px>150</buffer_px>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -34,7 +34,7 @@
                 <items_grid>.products-grid</items_grid>
                 <items_list>.products-list</items_list>
                 <loading>.column.main</loading>
-                <toolbar>.toolbar</toolbar>
+                <toolbar>.toolbar:not(:first)</toolbar>
                 <pagination>.toolbar .limiter</pagination>
             </selectors>
             <design>


### PR DESCRIPTION
This PR hides toolbar (pagination was hidden in #30, but limit appeared back, it's not needed when infinite scroll is enabled)