### PR TITLE
Remove meaningless text

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -40,7 +40,7 @@
             <design>
                 <loading_img><![CDATA[]]></loading_img>
                 <loading_text><![CDATA[<em>Loading products...</em>]]></loading_text>
-                <done_text><![CDATA[<em>Congratulations, you've reached the end of the internet.</em>]]></done_text>
+                <done_text></done_text>
                 <hide_toolbar>1</hide_toolbar>
                 <local_mode>0</local_mode>
                 <extra_scroll_px>150</extra_scroll_px>


### PR DESCRIPTION
This is follow up on https://github.com/Strategery-Inc/Magento2-InfiniteScroll/pull/37. 
Remove "Congratulations, you've reached the end of the internet." text. On production website it's better just not to add anything than adding such text.

Module should work fine out of the box and not add meaningless texts to existing pages.